### PR TITLE
Compute InitLaraFirestoreParams from context.

### DIFF
--- a/src/lara/helper-functions.ts
+++ b/src/lara/helper-functions.ts
@@ -24,7 +24,9 @@ export const getFirebaseJWT = (context: IExternalScriptContext, appname: string)
           const claims = JSON.parse(claimsJson);
           resolve({token: data, claims});
         } catch (error) {
+          // tslint:disable-next-line:no-console
           console.error("unable to parse JWT Token");
+          // tslint:disable-next-line:no-console
           console.error(error);
         }
         resolve({token: data, claims: {}});

--- a/src/lara/helper-functions.ts
+++ b/src/lara/helper-functions.ts
@@ -3,7 +3,8 @@ import {
   IJwtResponse,
   IJwtClaims,
   IClassInfo,
-  IInteractiveState
+  IInteractiveState,
+  IUser
 } from "./interfaces";
 import {
   SharedClassUserMap,
@@ -58,6 +59,17 @@ export const portalUserPathToFirebaseId = (portalUserPath: string) => {
   return portalUserPath.replace(replaceRegx, firebaseReplacement);
 };
 
+const studentValue = (student: IUser): string => {
+  const {first_name, last_name} = student;
+  const first = (first_name && first_name.length > 0)
+     ? first_name.charAt(0).toUpperCase() + first_name.slice(1)
+     : "";
+  const last = (last_name && last_name.length > 0)
+     ? last_name.charAt(0).toUpperCase() + first_name.slice(1)
+     : "";
+  return `${first} ${last}`;
+};
+
 export const getFireStoreParams = (
   context: IExternalScriptContext,
   jwt: IJwtResponse,
@@ -75,10 +87,11 @@ export const getFireStoreParams = (
     const classHash = classInfo.class_hash;
     // TODO: I don't think we need to initialize this from here....
     // This would erase all share info
-    // classInfo.students.forEach( (student) => {
-    //   const key = portalUserPathToFirebaseId(student.id);
-    //   userMap[key] = undefined;
-    // });
+    classInfo.students.forEach( (student) => {
+      const key = portalUserPathToFirebaseId(student.id);
+      const value = studentValue(student);
+      userMap[key] = value;
+    });
     return {
       rawFirebaseJWT,
       portalDomain,

--- a/src/lara/helper-functions.ts
+++ b/src/lara/helper-functions.ts
@@ -1,0 +1,91 @@
+import {
+  IExternalScriptContext,
+  IJwtResponse,
+  IJwtClaims,
+  IClassInfo,
+  IInteractiveState
+} from "./interfaces";
+import {
+  SharedClassUserMap,
+  InitLaraFirestoreParams
+} from "../stores/firestore";
+
+export const getFirebaseJWT = (context: IExternalScriptContext, appname: string): Promise<IJwtResponse> => {
+  const {getFirebaseJwtUrl, authoredState} = context;
+  return new Promise( (resolve, reject) => {
+    const appSpecificUrl = getFirebaseJwtUrl(appname);
+    fetch(appSpecificUrl, {method: "POST"})
+    .then( (response) => {
+      response.json()
+      .then( (data) => {
+        try {
+          const token = data.token.split(".")[1];
+          const claimsJson = atob(token);
+          const claims = JSON.parse(claimsJson);
+          resolve({token: data, claims});
+        } catch (error) {
+          console.error("unable to parse JWT Token");
+          console.error(error);
+        }
+        resolve({token: data, claims: {}});
+      });
+    });
+  });
+};
+
+export const getClassInfo = (context: IExternalScriptContext): Promise<IClassInfo> => {
+  const {classInfoUrl} = context;
+  return new Promise( (resolve, reject) => {
+    fetch(classInfoUrl, {method: "get", credentials: "include"})
+    .then( (resp) => resp.json().then( (data) => resolve(data)));
+  });
+};
+
+export const getInteractiveState = (context: IExternalScriptContext): Promise<IInteractiveState> => {
+  const {interactiveStateUrl} = context;
+  return new Promise( (resolve, reject) => {
+    fetch(interactiveStateUrl, {method: "get", credentials: "include"})
+    .then( (resp) => resp.json().then( (data) => resolve(data)));
+  });
+};
+
+export const portalUserPathToFirebaseId = (portalUserPath: string) => {
+  const portalPathSeperator = "/";
+  const firebaseReplacement = "-";
+  const replaceRegx = new RegExp(portalPathSeperator, "g");
+  return portalUserPath.replace(replaceRegx, firebaseReplacement);
+};
+
+export const getFireStoreParams = (
+  context: IExternalScriptContext,
+  jwt: IJwtResponse,
+  classInfo: IClassInfo,
+  interactiveState: IInteractiveState): InitLaraFirestoreParams => {
+    const claims = (jwt.claims as IJwtClaims);
+    const rawFirebaseJWT = jwt.token;
+    const portalDomain = claims.domain;
+    const portalClaims = claims.claims;
+    const offeringId = `${portalClaims.offering_id}`;
+    const pluginId = context.pluginId;
+    const portalUserId = portalUserPathToFirebaseId(portalClaims.user_id);
+    const userMap: SharedClassUserMap = {};
+    const interactiveName = interactiveState.interactive_name;
+    const classHash = classInfo.class_hash;
+    // TODO: I don't think we need to initialize this from here....
+    // This would erase all share info
+    // classInfo.students.forEach( (student) => {
+    //   const key = portalUserPathToFirebaseId(student.id);
+    //   userMap[key] = undefined;
+    // });
+    return {
+      rawFirebaseJWT,
+      portalDomain,
+      offeringId,
+      pluginId,
+      portalUserId,
+      userMap,
+      interactiveName,
+      classHash,
+      type: "lara"
+    };
+};

--- a/src/lara/interfaces.ts
+++ b/src/lara/interfaces.ts
@@ -35,8 +35,8 @@ export interface IJwtResponse {
 
 export interface IUser {
   id: string; // path
-  firstName: string;
-  lastName: string;
+  first_name: string;
+  last_name: string;
 }
 export interface IOffering {
   id: number;

--- a/src/lara/interfaces.ts
+++ b/src/lara/interfaces.ts
@@ -3,8 +3,62 @@ export interface IExternalScriptContext {
   authoredState: string;
   learnerState: string;
   pluginId: string;
-  wrappedEmbeddableDiv?: any;
+  url: string;
+  pluginStateKey: string;
+  runID: number;
+  userEmail: string;
+  classInfoUrl: string;
+  remoteEndpoint: string;
+  interactiveStateUrl: string;
+  getFirebaseJwtUrl: (appName: string) => string;
+  wrappedEmbeddableDiv?: HTMLDivElement;
   wrappedEmbeddableContext?: any;
+}
+
+export interface IPortalClaims {
+  user_type: "learner" | "teacher";
+  user_id: string;
+  class_hash: string;
+  offering_id: number;
+}
+export interface IJwtClaims {
+  domain: string;
+  returnUrl: string;
+  externalId: number;
+  class_info_url: string;
+  claims: IPortalClaims;
+}
+export interface IJwtResponse {
+  token: string;
+  claims: IJwtClaims | {};
+}
+
+export interface IUser {
+  id: string; // path
+  firstName: string;
+  lastName: string;
+}
+export interface IOffering {
+  id: number;
+  name: string;
+  url: string;
+}
+export interface IClassInfo {
+  id: number;
+  uri: string;
+  class_hash: string;
+  teachers: IUser[];
+  students: IUser[];
+  offerings: IOffering[];
+}
+
+export interface IInteractiveState {
+  id: number;
+  key: string;
+  raw_data: string;
+  interactive_name: string;
+  interactive_state_url: string;
+  activity_name: string;
 }
 
 // WARNING: Please refer to the latest LARA Api from the LARA project.

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -2,8 +2,17 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import PluginApp from "./components/plugin-app";
 import PluginConfig from "./config/plugin-config";
+import { IAuthoredState } from "./types";
 import {IExternalScriptContext, ILara} from "./lara/interfaces";
 import { store } from "./stores/firestore";
+import {
+  getFirebaseJWT,
+  getClassInfo,
+  getInteractiveState,
+  getFireStoreParams
+} from "./lara/helper-functions";
+
+const DefaultFirebaseApp = "test-app";
 
 // TODO: figure out store.init()
 // store.init({type: "lara"});
@@ -27,12 +36,24 @@ const getAuthoredState = (context: IExternalScriptContext) => {
 
 export class TeacherEditionTipsPlugin {
   public context: IExternalScriptContext;
+  public authoredState: IAuthoredState;
   public pluginAppComponent: any;
 
   constructor(context: IExternalScriptContext) {
     this.context = context;
+    this.authoredState = getAuthoredState(context);
     // TODO: add store.init() after getting all data from lara
-    this.renderPluginApp();
+    Promise.all([
+      getFirebaseJWT(context, this.authoredState.firebaseAppName || DefaultFirebaseApp),
+      getClassInfo(context),
+      getInteractiveState(context)
+    ])
+    .then( ([jwtResponse, classInfo, interactiveState]) => {
+      const config = getFireStoreParams(context, jwtResponse, classInfo, interactiveState);
+      console.log(config);
+      store.init(config);
+      this.renderPluginApp();
+    });
   }
 
   public renderPluginApp = () => {

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -42,7 +42,6 @@ export class TeacherEditionTipsPlugin {
   constructor(context: IExternalScriptContext) {
     this.context = context;
     this.authoredState = getAuthoredState(context);
-    // TODO: add store.init() after getting all data from lara
     Promise.all([
       getFirebaseJWT(context, this.authoredState.firebaseAppName || DefaultFirebaseApp),
       getClassInfo(context),
@@ -53,6 +52,9 @@ export class TeacherEditionTipsPlugin {
       // tslint:disable-next-line:no-console
       console.log(config);
       store.init(config);
+      // If we call `renderPluginApp()` before `store.init()` we get
+      //     Error: Firestore store not initialized!
+      //     at ensureInitalized (firestore.ts:164)
       this.renderPluginApp();
     });
   }

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -50,6 +50,7 @@ export class TeacherEditionTipsPlugin {
     ])
     .then( ([jwtResponse, classInfo, interactiveState]) => {
       const config = getFireStoreParams(context, jwtResponse, classInfo, interactiveState);
+      // tslint:disable-next-line:no-console
       console.log(config);
       store.init(config);
       this.renderPluginApp();

--- a/src/stores/firestore.ts
+++ b/src/stores/firestore.ts
@@ -34,6 +34,7 @@ export interface InitLaraFirestoreParams {
   rawFirebaseJWT: string;
   portalDomain: string;
   offeringId: string;
+  classHash: string;
   pluginId: string;
   portalUserId: string;
   userMap: SharedClassUserMap;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,5 @@
  */
 export interface IAuthoredState {
   textContent: string;
+  firebaseAppName?: string;
 }


### PR DESCRIPTION
This work is not yet complete, but it does the job of pulling in the required configuration information from the portal and from LARA and initializing Firebase  before rendering the react component. I have questions about how to correctly initialize firebase. TBD.

In order to get this to "work" locally (where work just means printing the store configuration in the console) you will need to:

* add a firebaseApp secret to your portal.  
* Add the plugin to an activity.
* Configure the plugin by specifying the same firebaseAppName in JSON for the authoring data of the plugin, eg:
`{ "firebaseAppName" : "plugin-test" }`

This is part of:

[#161772107]  Display Publish/Sharing Option for Students

https://www.pivotaltracker.com/story/show/161772107