### PR TITLE
Add unread comments badge

### DIFF
--- a/src/components/icons/new-comment-badge.svg
+++ b/src/components/icons/new-comment-badge.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
+    <g fill="none" fill-rule="evenodd">
+        <g fill-rule="nonzero">
+            <g>
+                <g>
+                    <path fill="#1D8500" d="M4 0c2.21 0 4 1.79 4 4S6.21 8 4 8 0 6.21 0 4s1.79-4 4-4z" transform="translate(-801 -660) translate(781 620) translate(20 40)"/>
+                    <path fill="#5FFF32" d="M4 1.5C2.62 1.5 1.5 2.62 1.5 4S2.62 6.5 4 6.5 6.5 5.38 6.5 4 5.38 1.5 4 1.5z" transform="translate(-801 -660) translate(781 620) translate(20 40)"/>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/sharing-wrapper.sass
+++ b/src/components/sharing-wrapper.sass
@@ -10,8 +10,17 @@
     left: 0px;
     right: 0px;
     height: 24px;
-    text-align: right;
     color: white;
+    display: flex;
+    justify-content: flex-end;
+    margin-right: 5px;
+
+    .icons
+      padding-right: 7px;
 
   svg
     box-sizing: content-box;
+
+    &.newCommentBadge
+      position: absolute
+      transform: translateX(-10px)

--- a/src/components/sharing-wrapper.tsx
+++ b/src/components/sharing-wrapper.tsx
@@ -4,6 +4,7 @@ import { IAuthoredState } from "../types";
 import ButtonShareIcon from "./icons/button-share.svg";
 import ButtonUnShareIcon from "./icons/button-unshare.svg";
 import ViewClassIcon from "./icons/view-class.svg";
+import NewCommentBadge from "./icons/new-comment-badge.svg";
 import ViewClass from "./view-class-work/view-class";
 import ShareModal from "./share-modal";
 import ToggleButton from "./toggle-button";
@@ -108,22 +109,39 @@ export class SharingWrapper extends React.Component<ISharingWrapperProps, IState
       const shareIcon = currentUserIsShared ? <ButtonUnShareIcon /> : <ButtonShareIcon />;
       const shareTip = currentUserIsShared ? "Stop sharing" : "Share this";
       const viewTip = "View class work";
+
+      let hasNewComments = false;
+      const currentUser = sharedClassData.students.find(s => s.isCurrentUser);
+      if (currentUser && currentUserIsShared) {
+        const lastSeen = currentUser.lastCommentSeen;
+        hasNewComments = !currentUser.commentsReceived.every(comment => {
+          return comment.time < lastSeen;
+        });
+      }
+
       return (
         <div className={headerClass} style={{width: interactiveWidth}}>
-          <ToggleButton
-            onClick={this.toggleShared}
-            enabled={interactiveAvailable}
-            tip={shareTip}
-          >
-            {shareIcon}
-          </ToggleButton>
-          <ToggleButton
-            onClick={this.toggleShowView}
-            enabled={interactiveAvailable && currentUserIsShared}
-            tip={viewTip}
-          >
-            <ViewClassIcon/>
-          </ToggleButton>
+          <div className={css.icons}>
+            <ToggleButton
+              onClick={this.toggleShared}
+              enabled={interactiveAvailable}
+              tip={shareTip}
+            >
+              {shareIcon}
+            </ToggleButton>
+            <ToggleButton
+              onClick={this.toggleShowView}
+              enabled={interactiveAvailable && currentUserIsShared}
+              tip={viewTip}
+            >
+              <ViewClassIcon/>
+              {
+                hasNewComments ?
+                  <NewCommentBadge className={css.newCommentBadge} /> :
+                  null
+              }
+            </ToggleButton>
+          </div>
         </div>
       );
     }

--- a/src/components/toggle-button.tsx
+++ b/src/components/toggle-button.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 import * as css from "./toggle-button.sass";
 import * as ReactTooltip from "react-tooltip";
 
+type MaybeElement = JSX.Element | null;
+
 interface IToggleButtonProps {
   onClick: (() => void) | undefined;
   enabled: boolean;
   tip: string;
-  children: string[] | JSX.Element[] | JSX.Element | undefined;
+  children: string[] | MaybeElement[] | JSX.Element | undefined;
 }
 
 const ToggleButton = (props: IToggleButtonProps) => {


### PR DESCRIPTION
This adds a small green icon next to the wrapper's View Class Work icon if there are new comments for this user.

This can be tested at http://lara-sharing-plugin.concord.org/branch/add-unread-comments-badge/demo.html

<img width="258" alt="Screen Shot 2021-03-23 at 11 41 07 AM" src="https://user-images.githubusercontent.com/35721/112174274-aacbbc00-8bcc-11eb-8f86-af0f419fa2b9.png">

(Note, the demo page has slightly weird sizing, the top-right buttons are better positioned in LARA)

After you view the comments for your own shared work, the icon will go away.