### PR TITLE
Comments style fixes

### DIFF
--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -15,6 +15,7 @@ $cc-charcoal: #3f3f3f
 $cc-charcoal-hint: #828282
 $cc-charcoal-light-1: #979797
 $cc-charcoal-light-2: #dfdfdf
+$cc-charcoal-light-3: #efefef
 $cc-teal-dark-2: #016082
 $cc-teal-dark-1: #0481a0
 $cc-teal: #0592af

--- a/src/components/view-class-work/delete-confirm-modal.sass
+++ b/src/components/view-class-work/delete-confirm-modal.sass
@@ -67,7 +67,7 @@ $titleBarHeight: 30px
       .submit
         position: absolute
         bottom: 15px
-        right: 5px
+        right: 15px
         display: flex
         justify-content: flex-end
 

--- a/src/components/view-class-work/left-nav.sass
+++ b/src/components/view-class-work/left-nav.sass
@@ -125,6 +125,7 @@
       background-color: $cc-teal-light-6
       border: 1.5px solid $cc-charcoal-light-1
       border-radius: $button-radius
+      cursor: pointer
 
       svg
         margin-right: 5px
@@ -134,10 +135,15 @@
         font-size: 15px
         font-weight: bold
 
-      &:hover
+      &:hover:enabled
         background-color: $cc-teal-light-4
-      &:active
+      &:active:enabled
         color: white
         background-color: $cc-teal
         svg
           fill: white
+      &:disabled
+        background-color: $cc-charcoal-light-3
+        cursor: auto
+        svg
+          fill: $cc-charcoal-light-1

--- a/src/components/view-class-work/left-nav.sass
+++ b/src/components/view-class-work/left-nav.sass
@@ -106,6 +106,7 @@
     .commentInput
       width: 210px
       height: 75px
+      min-height: 75px
       margin: 5px 0 5px 15px
       padding: 7px
       box-sizing: border-box

--- a/src/components/view-class-work/left-nav.sass
+++ b/src/components/view-class-work/left-nav.sass
@@ -72,6 +72,7 @@
         color: $cc-charcoal
 
         svg
+          min-width: 24px
           cursor: pointer
           fill: $cc-teal-light-4
 

--- a/src/components/view-class-work/left-nav.tsx
+++ b/src/components/view-class-work/left-nav.tsx
@@ -128,6 +128,8 @@ export const LeftNav = (props: ILeftNavProps) => {
     }
   }, [currentUserId, newCommentLineRef.current, lastCommentRef.current]);
 
+  const submitEnabled = selectedStudent && newComment;
+
   return (
     <div className={css.leftNav}>
       {showingDeleteConfirm &&
@@ -189,7 +191,7 @@ export const LeftNav = (props: ILeftNavProps) => {
           />
           <button className={css.submitButton}
               onClick={handleSendComment}
-              disabled={!selectedStudent}>
+              disabled={!submitEnabled}>
             <IconSend />
             <div>Post comment</div>
           </button>

--- a/src/components/view-class-work/left-nav.tsx
+++ b/src/components/view-class-work/left-nav.tsx
@@ -22,6 +22,7 @@ export const LeftNav = (props: ILeftNavProps) => {
 
   const newCommentLineRef = useRef<HTMLDivElement>(null);
   const lastCommentRef = useRef<HTMLDivElement>(null);
+  const textBoxRef = useRef<HTMLTextAreaElement>(null);
 
   const currentUserId = sharedClassData.students.find(s => s.isCurrentUser)?.userId;
   const selectedStudent = sharedClassData.students.find(s => s.userId === selectedStudentId);
@@ -73,11 +74,15 @@ export const LeftNav = (props: ILeftNavProps) => {
     if (selectedStudentId) {
       store.markCommentsRead(selectedStudentId);
     }
+    if (!selectedStudent || !selectedStudent.commentsReceived.length || !lastCommentRef.current || !textBoxRef.current) return;
+
     // if our own comment is the last one, scroll to it
-    if (selectedStudent
-        && selectedStudent.commentsReceived.length > 0
-        && selectedStudent.commentsReceived[selectedStudent.commentsReceived.length - 1].sender === currentUserId
-        && lastCommentRef.current) {
+    const ownCommentIsLast = selectedStudent.commentsReceived[selectedStudent.commentsReceived.length - 1].sender === currentUserId;
+    // or if the previous message is in view
+    const lastCommentBox = lastCommentRef.current.getBoundingClientRect();
+    const inputBox = textBoxRef.current.getBoundingClientRect();
+    const previousMessageInView = lastCommentBox.y - inputBox.y < lastCommentBox.height;
+    if (ownCommentIsLast || previousMessageInView)   {
       lastCommentRef.current.scrollIntoView()
     }
   }, [currentStudentCommentsLength, lastCommentRef.current]);
@@ -189,6 +194,7 @@ export const LeftNav = (props: ILeftNavProps) => {
             value={newComment}
             onChange={handleNewCommentChange}
             disabled={!selectedStudent}
+            ref={textBoxRef}
           />
           <button className={css.submitButton}
               onClick={handleSendComment}

--- a/src/components/view-class-work/left-nav.tsx
+++ b/src/components/view-class-work/left-nav.tsx
@@ -75,6 +75,7 @@ export const LeftNav = (props: ILeftNavProps) => {
     }
     // if our own comment is the last one, scroll to it
     if (selectedStudent
+        && selectedStudent.commentsReceived.length > 0
         && selectedStudent.commentsReceived[selectedStudent.commentsReceived.length - 1].sender === currentUserId
         && lastCommentRef.current) {
       lastCommentRef.current.scrollIntoView()


### PR DESCRIPTION
This is a small collection of styling improvements, and then two slightly more complex commits, one which adds scrolling logic and one which improves the behavior of the new-comment indicator line.

The scrolling is designed so that if either (1) the user sends a comment, or (2) we are near the bottom of the comment list (defined as being able to see any of the previously-last comment) we scroll to the bottom when we get a new comment.

The new-comment indicator line is designed such that if you have *previously* seen a list of comments, and new comments come in while you're not looking, we'll show a line at your previous read location. The tricky part is that we don't want this line to move while you're looking at the message list, even if new comments come in.

The simple demo can be seen at http://lara-sharing-plugin.concord.org/branch/comments-style-fixes/demo.html