### PR TITLE
Use PluginAPI.setAnswerSharedWithClass to support new Portal Report reporting_urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,9 +1115,9 @@
       }
     },
     "@concord-consortium/lara-plugin-api": {
-      "version": "3.4.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-plugin-api/-/lara-plugin-api-3.4.0-pre.1.tgz",
-      "integrity": "sha512-8cONI4yxG/QIIahZKFxNglljxZEeU7CjaUC4I0iL+sVZ471qX5bnfgsKbpl3jezQNtC8nYBAebIpdj/f/uBPiA=="
+      "version": "3.4.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-plugin-api/-/lara-plugin-api-3.4.0-pre.2.tgz",
+      "integrity": "sha512-Aa3ZuDk3Cv9Mf80hV8JBwD9U93k5aoU1WFfbZO1rpYf9Pepl3rW+udqOFkgidhD3BpESENOBQ9ugW3u8z4/moA=="
     },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,9 +1115,9 @@
       }
     },
     "@concord-consortium/lara-plugin-api": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-plugin-api/-/lara-plugin-api-3.1.2.tgz",
-      "integrity": "sha512-dMfvunMs5dAXLainMEmShU8GlxwQk5BMkgErvujOSs7nHatfUnPykgeW3Bo/6IZLc5gYQE4D0yUoF5J8kbeyYQ=="
+      "version": "3.4.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-plugin-api/-/lara-plugin-api-3.4.0-pre.1.tgz",
+      "integrity": "sha512-8cONI4yxG/QIIahZKFxNglljxZEeU7CjaUC4I0iL+sVZ471qX5bnfgsKbpl3jezQNtC8nYBAebIpdj/f/uBPiA=="
     },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "@concord-consortium/lara-plugin-api": "^3.0.0-pre.18",
+    "@concord-consortium/lara-plugin-api": "3.4.0-pre.1",
     "firebase": "^8.2.9",
     "markdown-to-jsx": "^6.8.3",
     "query-string": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "@concord-consortium/lara-plugin-api": "3.4.0-pre.1",
+    "@concord-consortium/lara-plugin-api": "3.4.0-pre.2",
     "firebase": "^8.2.9",
     "markdown-to-jsx": "^6.8.3",
     "query-string": "^6.2.0",

--- a/src/components/sharing-wrapper.tsx
+++ b/src/components/sharing-wrapper.tsx
@@ -168,8 +168,8 @@ export class SharingWrapper extends React.Component<ISharingWrapperProps, IState
     const { type } = sharedClassData;
     const { getReportingUrl } = store;
 
-    const toggleShare = (iframeUrl: string) => {
-      const shared = store.toggleShare(iframeUrl);
+    const toggleShare = async (iframeUrl: string) => {
+      const shared = await store.toggleShare(iframeUrl);
       if (shared && !this.state.dontShowShareModal) {
         this.setState({showShareModal: true});
       }

--- a/src/lara/helper-functions.ts
+++ b/src/lara/helper-functions.ts
@@ -43,6 +43,7 @@ export const getFireStoreParams = (
     const onInteractiveAvailableFillIn = (handler: PluginAPI.IInteractiveAvailableEventHandler) => {};
     const onInteractiveAvailable = context.wrappedEmbeddable ? context.wrappedEmbeddable.onInteractiveAvailable : onInteractiveAvailableFillIn;
     const getReportingUrl = context.wrappedEmbeddable ? context.wrappedEmbeddable.getReportingUrl : () => new Promise<null>(resolve => resolve(null));
+    const setAnswerSharedWithClass = context.wrappedEmbeddable?.setAnswerSharedWithClass || (() => Promise.reject("Sharing not supported"));
     // ADD
     classInfo.students.forEach( (student) => {
       const key = portalUserPathToFirebaseId(student.id);
@@ -61,7 +62,8 @@ export const getFireStoreParams = (
       classHash,
       onInteractiveAvailable,
       interactiveAvailable,
-      getReportingUrl
+      getReportingUrl,
+      setAnswerSharedWithClass
     };
     return params;
 };

--- a/src/lara/helper-functions.ts
+++ b/src/lara/helper-functions.ts
@@ -25,8 +25,7 @@ const getDisplayName = (student: PluginAPI.IUser): string => {
 export const getFireStoreParams = (
   context: PluginAPI.IPluginRuntimeContext,
   jwt: PluginAPI.IJwtResponse,
-  classInfo: PluginAPI.IClassInfo,
-  interactiveState: PluginAPI.IInteractiveState
+  classInfo: PluginAPI.IClassInfo
 ): InitLaraFirestoreParams => {
     const claims = (jwt.claims as PluginAPI.IJwtClaims);
     const rawFirebaseJWT = jwt.token;
@@ -36,7 +35,7 @@ export const getFireStoreParams = (
     const pluginId = context.pluginId.toString();
     const portalUserId = portalUserPathToFirebaseId(portalClaims.user_id);
     const userMap: SharedClassUserMap = {};
-    const interactiveName = interactiveState.interactive_name;
+    const interactiveName = context.wrappedEmbeddable?.laraJson.name;
     const classHash = classInfo.class_hash;
     const interactiveAvailable = context.wrappedEmbeddable ? context.wrappedEmbeddable.interactiveAvailable : true;
     // tslint:disable-next-line:no-empty

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -56,13 +56,11 @@ export class LaraSharingPlugin {
 
     const firebasePromise = context.getFirebaseJwt(this.authoredState.firebaseAppName || DefaultFirebaseAppName);
     const classInfoPromise = context.getClassInfo();
-    const interactiveStatePromise = context.wrappedEmbeddable.getInteractiveState();
-    if (firebasePromise && classInfoPromise && interactiveStatePromise) {
-      Promise.all([ firebasePromise, classInfoPromise, interactiveStatePromise])
-      .then( ([jwtResponse, classInfo, interactiveState]) => {
-        const config = getFireStoreParams(context, jwtResponse, classInfo, interactiveState);
+    if (firebasePromise && classInfoPromise) {
+      Promise.all([ firebasePromise, classInfoPromise])
+      .then( ([jwtResponse, classInfo]) => {
+        const config = getFireStoreParams(context, jwtResponse, classInfo);
         // tslint:disable-next-line:no-console
-        console.log(config);
         store.init(config)
           .then(() => this.renderPluginApp())
           .catch((err) => alert(err.toString()));
@@ -89,7 +87,6 @@ export class LaraSharingAuthoringPlugin {
   public context: PluginAPI.IPluginAuthoringContext;
   public authoredState: IAuthoredState;
   public pluginAppComponent: any;
-  private currentFirebaseAppName?: string;
 
   constructor(context: PluginAPI.IPluginAuthoringContext) {
     this.context = context;

--- a/src/stores/firestore.ts
+++ b/src/stores/firestore.ts
@@ -66,7 +66,7 @@ export interface InitLaraFirestoreParams {
   interactiveAvailable: boolean;
   onInteractiveAvailable: (handler: PluginAPI.IInteractiveAvailableEventHandler) => void;
   getReportingUrl: () => Promise<string | null> | null;
-  setAnswerSharedWithClass: (enabled: boolean) => Promise<Response>;
+  setAnswerSharedWithClass: (enabled: boolean) => Promise<void>;
 }
 
 export type InitFirestoreParams = InitDemoFirestoreParams | InitTestFirestoreParams | InitLaraFirestoreParams;
@@ -86,7 +86,7 @@ export class FirestoreStore {
   public readonly type: "demo" | "test" | "lara";
   public interactiveAvailable: boolean = true;
   public getReportingUrl: () => Promise<string | null> | null;
-  public setAnswerSharedWithClass: (enabled: boolean) => Promise<Response>;
+  public setAnswerSharedWithClass: (enabled: boolean) => Promise<void>;
   private initialized: boolean;
   private listeners: FirestoreStoreListener[];
   private db: firebase.firestore.Firestore;
@@ -198,10 +198,7 @@ export class FirestoreStore {
 
   public async share(iframeUrl: string) {
     this.ensureInitalized();
-    const response = await this.setAnswerSharedWithClass(true);
-    if (response.status !== 200) {
-      throw new Error("Answer sharing has failed");
-    }
+    await this.setAnswerSharedWithClass(true);
     if (this.currentUser) {
       const { userId } = this.currentUser;
 
@@ -227,10 +224,7 @@ export class FirestoreStore {
 
   public async unshare() {
     this.ensureInitalized();
-    const response = await this.setAnswerSharedWithClass(false);
-    if (response.status !== 200) {
-      throw new Error("Answer unsharing has failed");
-    }
+    await this.setAnswerSharedWithClass(false);
     if (this.currentUser) {
       return this.db.runTransaction((transaction) => {
         // if the model has been shared, unsharing simply means wiping the iframeUrl.

--- a/src/stores/firestore.ts
+++ b/src/stores/firestore.ts
@@ -66,6 +66,7 @@ export interface InitLaraFirestoreParams {
   interactiveAvailable: boolean;
   onInteractiveAvailable: (handler: PluginAPI.IInteractiveAvailableEventHandler) => void;
   getReportingUrl: () => Promise<string | null> | null;
+  setAnswerSharedWithClass: (enabled: boolean) => Promise<Response>;
 }
 
 export type InitFirestoreParams = InitDemoFirestoreParams | InitTestFirestoreParams | InitLaraFirestoreParams;
@@ -85,6 +86,7 @@ export class FirestoreStore {
   public readonly type: "demo" | "test" | "lara";
   public interactiveAvailable: boolean = true;
   public getReportingUrl: () => Promise<string | null> | null;
+  public setAnswerSharedWithClass: (enabled: boolean) => Promise<Response>;
   private initialized: boolean;
   private listeners: FirestoreStoreListener[];
   private db: firebase.firestore.Firestore;
@@ -120,7 +122,7 @@ export class FirestoreStore {
         params.type === "test" ? "Test Interactive" :
         params.interactiveName
       );
-      const classData: SharedClassData = this.classData = {
+      this.classData = {
         type: params.type,
         currentUserIsShared: false,
         interactiveName,
@@ -145,6 +147,7 @@ export class FirestoreStore {
 
         case "lara":
           this.getReportingUrl = params.getReportingUrl;
+          this.setAnswerSharedWithClass = params.setAnswerSharedWithClass;
 
           this.interactiveAvailable = params.interactiveAvailable;
           params.onInteractiveAvailable(this.handleInteractiveAvailable);
@@ -178,23 +181,27 @@ export class FirestoreStore {
     };
   }
 
-  public toggleShare(iframeUrl: string) {
+  public async toggleShare(iframeUrl: string) {
     this.ensureInitalized();
     if (this.classData) {
       if (this.classData.currentUserIsShared) {
-        this.unshare();
+        await this.unshare();
         return false;
       }
       else {
-        this.share(iframeUrl);
+        await this.share(iframeUrl);
         return true;
       }
     }
     return false;
   }
 
-  public share(iframeUrl: string) {
+  public async share(iframeUrl: string) {
     this.ensureInitalized();
+    const response = await this.setAnswerSharedWithClass(true);
+    if (response.status !== 200) {
+      throw new Error("Answer sharing has failed");
+    }
     if (this.currentUser) {
       const { userId } = this.currentUser;
 
@@ -218,8 +225,12 @@ export class FirestoreStore {
     }
   }
 
-  public unshare() {
+  public async unshare() {
     this.ensureInitalized();
+    const response = await this.setAnswerSharedWithClass(false);
+    if (response.status !== 200) {
+      throw new Error("Answer unsharing has failed");
+    }
     if (this.currentUser) {
       return this.db.runTransaction((transaction) => {
         // if the model has been shared, unsharing simply means wiping the iframeUrl.


### PR DESCRIPTION
[#179466138]

Use new PluginAPI.setAnswerSharedWithClass function to share an answer with other students. This is necessary to support new reporting_urls that are now using Portal Report.