### PR TITLE
Refactor global store, so multiple plugin instances can be used on the same page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 # cf. https://stackoverflow.com/a/52387639
 install:
 - travis_retry gem install s3_website -v 3.4.0
+- travis_retry pyenv global 3.6
 - travis_retry pip install awscli --upgrade --user
 - travis_retry npm ci
 - travis_retry cypress install

--- a/src/components/authoring/authoring-app.tsx
+++ b/src/components/authoring/authoring-app.tsx
@@ -6,7 +6,7 @@ import JsonEditor from "./json-editor";
 
 import { IAuthoredState } from "../../types";
 import PluginComponent from "./interactive-and-wrapper";
-import { store } from "../../stores/firestore";
+import { FirestoreStore } from "../../stores/firestore";
 
 const defaultProps: IAuthoredState = {
 };
@@ -60,6 +60,7 @@ export default class AuthoringApp extends React.Component<IProps, IState> {
 
 const targetDiv = document.getElementById("window-shade-editor");
 
+const store = new FirestoreStore();
 store.init({type: "demo"}).then (() => {
   ReactDOM.render(<AuthoringApp initialAuthoredState={defaultProps}/>, targetDiv);
 });

--- a/src/components/sharing-wrapper.test.tsx
+++ b/src/components/sharing-wrapper.test.tsx
@@ -3,8 +3,9 @@ import {
   SharingWrapper,
   ISharingWrapperProps
 } from "./sharing-wrapper";
-import { render } from "enzyme";
+import { mount } from "enzyme";
 import { FirestoreStore } from "../stores/firestore";
+import ToggleButton from "./toggle-button";
 
 const store = new FirestoreStore();
 
@@ -16,19 +17,17 @@ const props: ISharingWrapperProps = {
 };
 
 describe("Sharing Wrapper", () => {
-  it("renders two SVG buttons", () => {
+  it("renders two SVG buttons", (done) => {
     store.init({type: "test"})
     .then(() => {
-      const wrapper = render(
+      const wrapper = mount(
         <SharingWrapper
           authoredState={props.authoredState}
           wrappedEmbeddableDiv={props.wrappedEmbeddableDiv}
           store={props.store} />
       );
-      expect(wrapper.find(".wrappedHeader .button").length).toBe(2);
-    })
-    .catch((err) => {
-      throw new Error(err.toString());
+      expect(wrapper.find(ToggleButton).length).toBe(2);
+      done();
     });
   });
 });

--- a/src/components/sharing-wrapper.test.tsx
+++ b/src/components/sharing-wrapper.test.tsx
@@ -4,8 +4,9 @@ import {
   ISharingWrapperProps
 } from "./sharing-wrapper";
 import { render } from "enzyme";
-import { store } from "../stores/firestore";
-const testingText =  "Hello World!";
+import { FirestoreStore } from "../stores/firestore";
+
+const store = new FirestoreStore();
 
 const props: ISharingWrapperProps = {
   authoredState: {

--- a/src/components/view-class-work/left-nav.tsx
+++ b/src/components/view-class-work/left-nav.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
-import { CommentReceived, SharedClassData, store } from "../../stores/firestore";
+import { CommentReceived, FirestoreStore, SharedClassData } from "../../stores/firestore";
 import { SplitPane } from "../split-pane";
 import IconAccountId from "../icons/account-id-badge.svg";
 import IconAccountIdPosted from "../icons/account-id-badge-posted.svg";
@@ -14,10 +14,11 @@ export interface ILeftNavProps {
   sharedClassData: SharedClassData | null;
   selectedStudentId: string | null;
   onSelectStudent: (selectedStudent: string) => void;
+  store: FirestoreStore;
 }
 
 export const LeftNav = (props: ILeftNavProps) => {
-  const {sharedClassData, selectedStudentId, onSelectStudent} = props;
+  const {sharedClassData, selectedStudentId, onSelectStudent, store} = props;
   if (!sharedClassData) return null;
 
   const lastCommentRef = useRef<HTMLDivElement>(null);

--- a/src/components/view-class-work/view-class.tsx
+++ b/src/components/view-class-work/view-class.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as screenfull from "screenfull";
 import { LeftNav } from "./left-nav";
-import { SharedClassData, SharedStudentData, FirestoreStore } from "../../stores/firestore";
+import { SharedClassData, FirestoreStore } from "../../stores/firestore";
 
 import * as css from "./view-class.sass";
 import ViewSharedIcon from "../icons/view-shared.svg";
@@ -28,7 +28,7 @@ export class ViewClass extends React.Component<IViewClassProps, IState> {
   private iFrameRef: React.RefObject<HTMLIFrameElement> = React.createRef();
 
   public render() {
-    const { sharedClassData } = this.props;
+    const { sharedClassData, store } = this.props;
     const interactiveName = sharedClassData ? sharedClassData.interactiveName : null;
     const haveInteractiveName = (interactiveName !== null) && (interactiveName.length > 0);
 
@@ -48,6 +48,7 @@ export class ViewClass extends React.Component<IViewClassProps, IState> {
           sharedClassData={sharedClassData}
           selectedStudentId={this.state.selectedStudentId}
           onSelectStudent={this.handleSelectStudent}
+          store={store}
         />
         <div className={css.viewer}>
           {this.renderViewer()}

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -3,11 +3,12 @@ import * as ReactDOM from "react-dom";
 
 import { IAuthoredState} from "./types";
 import InteractiveAndWrapper from "./components/authoring/interactive-and-wrapper";
-import { store } from "./stores/firestore";
+import { FirestoreStore } from "./stores/firestore";
 
 const authoredState: IAuthoredState = {
 };
 
+const store = new FirestoreStore();
 store.init({type: "demo"})
   .then(() => {
     ReactDOM.render(

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -4,7 +4,7 @@ import PluginApp from "./components/plugin-app";
 import PluginConfig from "./config/plugin-config";
 import { DefaultFirebaseAppName } from "./config/plugin-config";
 import { IAuthoredState } from "./types";
-import { store } from "./stores/firestore";
+import { FirestoreStore } from "./stores/firestore";
 import {
   getFireStoreParams
 } from "./lara/helper-functions";
@@ -31,6 +31,7 @@ export class LaraSharingPlugin {
   public context: PluginAPI.IPluginRuntimeContext;
   public authoredState: IAuthoredState;
   public pluginAppComponent: any;
+  public store: FirestoreStore;
 
   constructor(context: PluginAPI.IPluginRuntimeContext) {
     const errMsg = "Plugin context is incorrect, the plugin instance has been configured incorrectly.";
@@ -42,7 +43,7 @@ export class LaraSharingPlugin {
 
     this.context = context;
     this.authoredState = getAuthoredState(context);
-
+    this.store = new FirestoreStore();
 
     // Initial render, done as fast as possible, to re-add embedded interactive iframe before LARA starts
     // communication with it. Workaround for: https://www.pivotaltracker.com/story/show/177568401
@@ -61,7 +62,7 @@ export class LaraSharingPlugin {
       .then( ([jwtResponse, classInfo]) => {
         const config = getFireStoreParams(context, jwtResponse, classInfo);
         // tslint:disable-next-line:no-console
-        store.init(config)
+        this.store.init(config)
           .then(() => this.renderPluginApp())
           .catch((err) => alert(err.toString()));
       });
@@ -77,7 +78,7 @@ export class LaraSharingPlugin {
       <PluginApp
         authoredState={authoredState}
         wrappedEmbeddableDiv={this.context.wrappedEmbeddable && this.context.wrappedEmbeddable.container}
-        store={store}
+        store={this.store}
       />,
       this.context.container);
   }

--- a/src/stores/firestore.ts
+++ b/src/stores/firestore.ts
@@ -153,6 +153,7 @@ export class FirestoreStore {
 
       switch (params.type) {
         case "demo":
+          this.setAnswerSharedWithClass = () => Promise.resolve();
           firestoreLogin()
             .then(() => {
               const studentDemoData = this.createDemoData();


### PR DESCRIPTION
Sharing Plugin was failing when two instances were used on the same page. ActivityPlayer is a single-page app, so it's an obvious issue there - even if there's only one plugin per AP page, this was still one document and shared globals didn't work.