### PR TITLE
Update z-index so sharing plugin displays properly in AP Notebook. (PT-185395585)

### DIFF
--- a/src/components/share-modal.sass
+++ b/src/components/share-modal.sass
@@ -12,7 +12,7 @@ $titleBarHeight: 30px
   align-items: center
   justify-content: center
   height: 100%
-  z-index: 1
+  z-index: 100
 
   .dialog
     background-color: $cc-teal-light-7

--- a/src/components/view-class-work/delete-confirm-modal.sass
+++ b/src/components/view-class-work/delete-confirm-modal.sass
@@ -20,7 +20,7 @@ $titleBarHeight: 30px
     align-items: center
     justify-content: center
     height: 100%
-    z-index: 1
+    z-index: 100
 
     .dialog
       background-color: white

--- a/src/components/view-class-work/view-class.sass
+++ b/src/components/view-class-work/view-class.sass
@@ -8,7 +8,7 @@
   left: 20px
   background-color: #cfe2f3
   border-radius: $border-radius
-  z-index: 1
+  z-index: 100
   box-shadow: 0px 0px 11px 1px rgba(89,89,89,0.85)
 
   svg


### PR DESCRIPTION
The notebook layout in AP has to use higher indices for the styling of tabs and the spiral asset of the notebook. We have to update the sharing plugin to use higher z indices so it can display properly in that context.