### PR TITLE
build: Updated ci.yml to fix build and test issues [PT-185395585]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Install Dependencies
         run: npm ci
       - name: Build
@@ -21,16 +23,22 @@ jobs:
           flags: jest
   cypress:
     runs-on: ubuntu-latest
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
       # leaving the Dashboard hanging ...
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
+      matrix:
+        # run 3 copies of the current job in parallel
+        containers: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Install Dependencies
         run: npm ci
       - name: Build
@@ -41,6 +49,8 @@ jobs:
           wait-on: 'http://localhost:8080/'
           # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
           record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
+          # only do parallel if we have a record key
+          parallel: ${{ !!secrets.CYPRESS_RECORD_KEY }}
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -52,7 +62,7 @@ jobs:
           # should be much faster
           CODE_COVERAGE: true
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           flags: cypress
   s3-deploy:
@@ -60,12 +70,12 @@ jobs:
     needs:
       - build_test
       - cypress
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '14'
       - name: Install Depndencies
         run: npm ci
         env:


### PR DESCRIPTION
- Updated S3 deploy action to use ubuntu-latest and pinned to node 14
- Updated Cypress ci.yml settings
  - It now runs in a node 14 container
  - It runs the tests in parallel
  - It builds the code in a node 14 container before starting
- Updated build_test to pin to node 14
