### PR TITLE
fix: Sharing plugin modal z-index issues [PT-185637498]

### DIFF
--- a/cypress/integration/demo.test.ts
+++ b/cypress/integration/demo.test.ts
@@ -1,7 +1,7 @@
 const buttonSelector = ".toggle-button--button--SharingPluginV1";
 const modalCloseButton = ".share-modal--icon--SharingPluginV1";
 const closeModal = () => {
-  cy.get("#plugin").find(modalCloseButton).eq(1).click();
+  cy.get("body").find(modalCloseButton).eq(1).click();
 };
 
 context("Test the demo app", () => {
@@ -36,21 +36,21 @@ context("Test the demo app", () => {
       })
 
       it("does allow view class after share clicked", () => {
-        cy.get("#plugin").find(".view-class--viewClass--SharingPluginV1").should("exist");
-        cy.get("#plugin").find(".view-class--titleBarContents--SharingPluginV1").contains("Demo Interactive");
+        cy.get("body").find(".view-class--viewClass--SharingPluginV1").should("exist");
+        cy.get("body").find(".view-class--titleBarContents--SharingPluginV1").contains("Demo Interactive");
       });
 
       it("shows the list of students in the class view", () => {
-        cy.get("#plugin").find(".left-nav--students--SharingPluginV1>div").its("length").should("eq", 26);
+        cy.get("body").find(".left-nav--students--SharingPluginV1>div").its("length").should("eq", 26);
       });
 
       it("shows the message to click on a student's name in the class view", () => {
-        cy.get("#plugin").find(".view-class--viewerMessageContents--SharingPluginV1").first().contains("Click on a student's name to view their work.");
+        cy.get("body").find(".view-class--viewerMessageContents--SharingPluginV1").first().contains("Click on a student's name to view their work.");
       });
 
       it("shows the iframe when a student's name is clicked", () => {
-        cy.get("#plugin").find(".left-nav--students--SharingPluginV1 div").first().click();
-        cy.get("#plugin").find(".view-class--viewerInteractiveIFrame--SharingPluginV1").should("exist");
+        cy.get("body").find(".left-nav--students--SharingPluginV1 div").first().click();
+        cy.get("body").find(".view-class--viewerInteractiveIFrame--SharingPluginV1").should("exist");
       });
 
     });

--- a/src/components/share-modal.tsx
+++ b/src/components/share-modal.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import * as css from "./share-modal.sass";
 import SharedIcon from "./icons/shared.svg";
 import CloseIcon from "./icons/button-close.svg";
@@ -11,6 +12,22 @@ export interface IShareModalProps {
 
 export class ShareModal extends React.Component<IShareModalProps, {}> {
   private checkbox: HTMLInputElement | null;
+  private portalRoot: HTMLDivElement;
+
+  constructor(props: IShareModalProps) {
+    super(props);
+    this.portalRoot = document.createElement("div");
+    // make this rarely used portal root usage in the DOM easily visible in the future
+    this.portalRoot.classList.add("MANUALLY-INSERTED-PORTAL-ROOT-FOR-SHARE-MODAL");
+  }
+
+  public componentDidMount() {
+    document.body.appendChild(this.portalRoot);
+  }
+
+  public componentWillUnmount(): void {
+    setTimeout(() => document.body.removeChild(this.portalRoot), 1);
+  }
 
   public render() {
     const { sharedClassData } = this.props;
@@ -19,7 +36,7 @@ export class ShareModal extends React.Component<IShareModalProps, {}> {
 
     const message = `Your work ${haveInteractiveName ? `for ${interactiveName}` : ""} has been shared with your class.`;
 
-    return (
+    return ReactDOM.createPortal(
       <div className={css.shareModal}>
         <div className={css.dialog}>
           <div className={css.titleBar}>
@@ -36,8 +53,8 @@ export class ShareModal extends React.Component<IShareModalProps, {}> {
             <p><input type="checkbox" ref={(el) => this.checkbox = el} /> Do not show this message again.</p>
           </div>
         </div>
-      </div>
-    );
+      </div>,
+    this.portalRoot);
   }
 
   private handleClose = () => {

--- a/src/components/view-class-work/view-class.tsx
+++ b/src/components/view-class-work/view-class.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import * as screenfull from "screenfull";
 import { LeftNav } from "./left-nav";
 import { SharedClassData, FirestoreStore } from "../../stores/firestore";
@@ -26,13 +27,29 @@ export class ViewClass extends React.Component<IViewClassProps, IState> {
   };
 
   private iFrameRef: React.RefObject<HTMLIFrameElement> = React.createRef();
+  private portalRoot: HTMLDivElement;
+
+  constructor(props: IViewClassProps) {
+    super(props);
+    this.portalRoot = document.createElement("div");
+    // make this rarely used portal root usage in the DOM easily visible in the future
+    this.portalRoot.classList.add("MANUALLY-INSERTED-PORTAL-ROOT-FOR-VIEW-CLASS");
+  }
+
+  public componentDidMount() {
+    document.body.appendChild(this.portalRoot);
+  }
+
+  public componentWillUnmount(): void {
+    setTimeout(() => document.body.removeChild(this.portalRoot), 1);
+  }
 
   public render() {
     const { sharedClassData, store } = this.props;
     const interactiveName = sharedClassData ? sharedClassData.interactiveName : null;
     const haveInteractiveName = (interactiveName !== null) && (interactiveName.length > 0);
 
-    return (
+    return ReactDOM.createPortal(
       <div className={css.viewClass}>
         <div className={css.titleBar}>
           <div className={css.titleBarContents}>
@@ -53,8 +70,8 @@ export class ViewClass extends React.Component<IViewClassProps, IState> {
         <div className={css.viewer}>
           {this.renderViewer()}
         </div>
-      </div>
-    );
+      </div>,
+    this.portalRoot);
   }
 
   private renderViewer() {


### PR DESCRIPTION
After trying a few different approaches to fixing the sharing modals being hidden in the grid layout in AP due to the grid element's stacking context this fix switches to rendering the modals via createPortal in a dynamically inserted div at the end of the body for each render.

This approach ensures that the modals "escape" the grid layout.